### PR TITLE
Fix miss rasing ValidationError

### DIFF
--- a/prompts/utils/typing.py
+++ b/prompts/utils/typing.py
@@ -3,12 +3,10 @@ from typing import Any
 
 from pydantic import (
     SerializeAsAny,
-    ValidationError,
     ValidationInfo,
     ValidatorFunctionWrapHandler,
     WrapValidator,
 )
-from pydantic.error_wrappers import ErrorWrapper
 from typing_extensions import Annotated
 
 from ..artifact.base import BaseArtifact
@@ -51,7 +49,7 @@ def artifact_subtype_converter(
         info: The validation info to use.
 
     Raises:
-        ValidationError: If no subclass matches.
+        ValueError: If no subclass matches.
 
     Returns:
         The converted value.
@@ -66,16 +64,9 @@ def artifact_subtype_converter(
             if type.default == v.get("type", None):
                 return subclass.model_validate(v)
 
-    raise ValidationError(
-        [
-            ErrorWrapper(
-                ValueError(
-                    f"Invalid artifact type: {v.get('type', None)}. "
-                    f"Expected one of: {[subclass.model_fields['type'].default for subclass in get_all_subclasses(BaseArtifact)]}"
-                ),
-            )
-        ],
-        model=BaseArtifact,
+    raise ValueError(
+        f"Invalid artifact type: {v.get('type', None)}. "
+        f"Expected one of: {[subclass.model_fields['type'].default for subclass in get_all_subclasses(BaseArtifact)]}"
     )
 
 

--- a/prompts/utils/typing.py
+++ b/prompts/utils/typing.py
@@ -8,6 +8,7 @@ from pydantic import (
     ValidatorFunctionWrapHandler,
     WrapValidator,
 )
+from pydantic.error_wrappers import ErrorWrapper
 from typing_extensions import Annotated
 
 from ..artifact.base import BaseArtifact
@@ -64,7 +65,18 @@ def artifact_subtype_converter(
         if type := subclass.model_fields.get("type"):
             if type.default == v.get("type", None):
                 return subclass.model_validate(v)
-    raise ValidationError("No subclass matched.")
+
+    raise ValidationError(
+        [
+            ErrorWrapper(
+                ValueError(
+                    f"Invalid artifact type: {v.get('type', None)}. "
+                    f"Expected one of: {[subclass.model_fields['type'].default for subclass in get_all_subclasses(BaseArtifact)]}"
+                ),
+            )
+        ],
+        model=BaseArtifact,
+    )
 
 
 AnyArtifact = Annotated[


### PR DESCRIPTION
This pull request updates the error handling in the `artifact_subtype_converter` function within `prompts/utils/typing.py`. The changes replace the use of `ValidationError` with `ValueError` and improve the error message for better clarity. The official Pydantic V2 documentation explicitly states that validation code should raise ValueError or AssertionError, not ValidationError directly

### Error handling improvements:

* Removed the import of `ValidationError` from the `pydantic` library, as it is no longer used in the file.
* Updated the `artifact_subtype_converter` function to raise a `ValueError` instead of a `ValidationError` when no subclass matches the given artifact type.
* Enhanced the error message in the `ValueError` to include the invalid artifact type and a list of expected types for better debugging.